### PR TITLE
remove sync for select API calls

### DIFF
--- a/src/main/java/com/iota/iri/service/API.java
+++ b/src/main/java/com/iota/iri/service/API.java
@@ -91,7 +91,6 @@ public class API {
     private Undertow server;
 
     private final Gson gson = new GsonBuilder().create();
-    private volatile PearlDiver pearlDiver = new PearlDiver();
 
     private final AtomicInteger counter = new AtomicInteger(0);
 
@@ -674,7 +673,7 @@ public class API {
       * @return {@link com.iota.iri.service.dto.GetTransactionsToApproveResponse}
       * @throws Exception When tip selection has failed. Currently caught and returned as an {@link ErrorResponse}.
       **/
-    private synchronized AbstractResponse getTransactionsToApproveStatement(int depth, Optional<Hash> reference) throws Exception {
+    private AbstractResponse getTransactionsToApproveStatement(int depth, Optional<Hash> reference) throws Exception {
         if (depth < 0 || depth > instance.configuration.getMaxDepth()) {
             return ErrorResponse.create("Invalid depth input");
         }
@@ -782,8 +781,7 @@ public class API {
       * @return {@link com.iota.iri.service.dto.AbstractResponse.Emptyness}
       **/
     private AbstractResponse interruptAttachingToTangleStatement(){
-        pearlDiver.cancel();
-        return AbstractResponse.createEmptyResponse();
+        throw new NotImplementedException(NOT_SUPPORTED);
     }
 
     /**
@@ -1103,13 +1101,13 @@ public class API {
       * @param trytes the list of trytes to prepare for network attachment, by doing proof of work.
       * @return The list of transactions in trytes, ready to be broadcast to the network.
       **/
-    public synchronized List<String> attachToTangleStatement(Hash trunkTransaction, Hash branchTransaction,
+    public List<String> attachToTangleStatement(Hash trunkTransaction, Hash branchTransaction,
                                                              int minWeightMagnitude, List<String> trytes) {
         
         final List<TransactionViewModel> transactionViewModels = new LinkedList<>();
 
         Hash prevTransaction = null;
-        pearlDiver = new PearlDiver();
+        PearlDiver pearlDiver = new PearlDiver();
 
         byte[] transactionTrits = Converter.allocateTritsForTrytes(TRYTES_SIZE);
 
@@ -1350,7 +1348,7 @@ public class API {
      * @param address The address to add the message to
      * @param message The message to store
      **/
-    private synchronized AbstractResponse storeMessageStatement(String address, String message) throws Exception {
+    private AbstractResponse storeMessageStatement(String address, String message) throws Exception {
         final List<Hash> txToApprove = getTransactionToApproveTips(3, Optional.empty());
 
         final int txMessageSize = TransactionViewModel.SIGNATURE_MESSAGE_FRAGMENT_TRINARY_SIZE / 3;


### PR DESCRIPTION
# Description

In order to run storeMessage, GTTA, attachToTangle in parallel the `synchronized` was removed.
This is possible due to the (current) lack of state in CLIRI :)

Fixes #36 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- 10 user agents running in parallel issuing `storeMessage`
