### PR TITLE
Bugfix: getRandomTipPoint() fails when tip is null

### DIFF
--- a/src/main/java/com/iota/iri/controllers/TipsViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TipsViewModel.java
@@ -61,7 +61,7 @@ public class TipsViewModel {
         synchronized (sync) {
             int size = solidTips.size();
             if (size == 0) {
-                return getRandomNonSolidTipHash();
+                throw new RuntimeException("Failed to get random tip, most likely a bootstrapping issue.");
             }
             int index = seed.nextInt(size);
             Iterator<Hash> hashIterator;

--- a/src/main/java/com/iota/iri/controllers/TipsViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TipsViewModel.java
@@ -61,7 +61,7 @@ public class TipsViewModel {
         synchronized (sync) {
             int size = solidTips.size();
             if (size == 0) {
-                throw new RuntimeException("Failed to get random tip, most likely a bootstrapping issue.");
+                return null;
             }
             int index = seed.nextInt(size);
             Iterator<Hash> hashIterator;

--- a/src/main/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorCumulativeWeightThreshold.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorCumulativeWeightThreshold.java
@@ -34,7 +34,10 @@ public class EntryPointSelectorCumulativeWeightThreshold implements EntryPointSe
 
     @Override
     public Hash getEntryPoint() throws Exception {
-        return backtrack(tipsViewModel.getRandomSolidTipHash(), threshold);
+        Hash solidTip = tipsViewModel.getRandomSolidTipHash();
+        Objects.requireNonNull(solidTip, "Failed to get random tip, most likely a bootstrapping issue.");
+
+        return backtrack(solidTip, threshold);
     }
 
     public Hash backtrack(Hash tip, int threshold) throws Exception {

--- a/src/test/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorCumulativeWeightThresholdTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorCumulativeWeightThresholdTest.java
@@ -11,7 +11,9 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.Rule;
 import org.mockito.Mockito;
+import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +25,9 @@ public class EntryPointSelectorCumulativeWeightThresholdTest {
     private static final TemporaryFolder logFolder = new TemporaryFolder();
     private static Tangle tangle;
     private static TipsViewModel tipsViewModel;
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
     @AfterClass
     public static void tearDown() throws Exception {
@@ -83,5 +88,16 @@ public class EntryPointSelectorCumulativeWeightThresholdTest {
 
         Assert.assertNotEquals(Hash.NULL_HASH, entryPoint);
         Assert.assertEquals(transactions.get(transactions.size() - threshold).getHash(), entryPoint);
+    }
+
+    @Test
+    public void failsWhenSolidTipIsNull() throws Exception {
+        final int threshold = 50;
+        Mockito.when(tipsViewModel.getRandomSolidTipHash()).thenReturn(null);
+        
+        EntryPointSelector entryPointSelector = new EntryPointSelectorCumulativeWeightThreshold(tangle, tipsViewModel, threshold);
+
+        exception.expect(NullPointerException.class);
+        entryPointSelector.getEntryPoint();
     }
 }


### PR DESCRIPTION
Pending a fix for #54, this will prevent nodes from crashing when getting GTTA requests