### PR TITLE
Recycle database weekly (Big Crunch)

### DIFF
--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -117,7 +117,7 @@ public class Iota {
         udpReceiver.init();
         replicator.init();
         node.init();
-        databaseRecycler.init(new Date());
+        databaseRecycler.init(new Date(System.currentTimeMillis()));
     }
 
     private void rescanDb() throws Exception {

--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -9,6 +9,7 @@ import com.iota.iri.network.TransactionRequester;
 import com.iota.iri.network.UDPReceiver;
 import com.iota.iri.network.replicator.Replicator;
 import com.iota.iri.service.TipsSolidifier;
+import com.iota.iri.service.DatabaseRecycler;
 import com.iota.iri.service.tipselection.*;
 import com.iota.iri.service.tipselection.impl.*;
 import com.iota.iri.storage.*;
@@ -18,6 +19,7 @@ import com.iota.iri.zmq.MessageQ;
 
 import java.security.SecureRandom;
 import java.util.List;
+import java.util.Date;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
@@ -69,6 +71,7 @@ public class Iota {
     public final TipsViewModel tipsViewModel;
     public final MessageQ messageQ;
     public final TipSelector tipsSelector;
+    public final DatabaseRecycler databaseRecycler;
 
     /**
      * Creates all services needed to run an IOTA node.
@@ -89,6 +92,7 @@ public class Iota {
         ledgerValidator = new LedgerValidatorImpl();
         tipsSolidifier = new TipsSolidifier(tangle, transactionValidator, tipsViewModel);
         tipsSelector = createTipSelector(configuration);
+        databaseRecycler = new DatabaseRecycler(transactionValidator, transactionRequester, tipsViewModel, tangle);
     }
 
     /**
@@ -113,6 +117,7 @@ public class Iota {
         udpReceiver.init();
         replicator.init();
         node.init();
+        databaseRecycler.init(new Date());
     }
 
     private void rescanDb() throws Exception {

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -112,6 +112,11 @@ public class TransactionValidator {
         newSolidThread.join();
     }
 
+    public void clear() throws Exception {
+        newSolidTransactionsOne.clear();
+        newSolidTransactionsTwo.clear();
+    }
+
     /**
      * @return the minimal number of trailing 9s that have to be present at the end of the transaction hash
      * in order to validate that sufficient proof of work has been done

--- a/src/main/java/com/iota/iri/TransactionValidator.java
+++ b/src/main/java/com/iota/iri/TransactionValidator.java
@@ -112,7 +112,7 @@ public class TransactionValidator {
         newSolidThread.join();
     }
 
-    public void clear() throws Exception {
+    public void clearSolidTransactionsQueue() throws Exception {
         newSolidTransactionsOne.clear();
         newSolidTransactionsTwo.clear();
     }

--- a/src/main/java/com/iota/iri/controllers/TipsViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TipsViewModel.java
@@ -111,6 +111,13 @@ public class TipsViewModel {
         }
     }
 
+    public void clear() {
+        synchronized (sync) {
+            tips.clear();
+            solidTips.clear();
+        }
+    }
+
     private class FifoHashCache<K> {
 
         private final int capacity;
@@ -143,6 +150,10 @@ public class TipsViewModel {
 
         public Iterator<K> iterator() {
             return this.set.iterator();
+        }
+
+        public void clear() {
+            set.clear();
         }
     }
 

--- a/src/main/java/com/iota/iri/network/TransactionRequester.java
+++ b/src/main/java/com/iota/iri/network/TransactionRequester.java
@@ -127,4 +127,8 @@ public class TransactionRequester {
         return hash;
     }
 
+    public void clearQueue() {
+        transactionsToRequest.clear();
+    }
+
 }

--- a/src/main/java/com/iota/iri/service/DatabaseRecycler.java
+++ b/src/main/java/com/iota/iri/service/DatabaseRecycler.java
@@ -25,6 +25,7 @@ import ch.qos.logback.core.util.Duration;
  * to cap hard disk usage until local snapshots are merged into CLIRI.
  */
 public class DatabaseRecycler {
+    public final long acceptableLatency = Duration.buildByMinutes(10).getMilliseconds();
 
     private final Logger log = LoggerFactory.getLogger(TipsSolidifier.class);
 
@@ -56,7 +57,7 @@ public class DatabaseRecycler {
     protected final Runnable recycle = new Runnable() {
         public void run() {
             log.info(String.format("Recycling database at %s", new Date().toString()));
-            TransactionValidator.setLatestEpochTimestamp(System.currentTimeMillis());
+            TransactionValidator.setLatestEpochTimestamp(System.currentTimeMillis() - acceptableLatency);
             transactionRequester.clearQueue();
             tipsViewModel.clear();
 

--- a/src/main/java/com/iota/iri/service/DatabaseRecycler.java
+++ b/src/main/java/com/iota/iri/service/DatabaseRecycler.java
@@ -1,0 +1,71 @@
+package com.iota.iri.service;
+
+import static java.time.DayOfWeek.SUNDAY;
+import static java.time.temporal.TemporalAdjusters.next;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import com.iota.iri.TransactionValidator;
+import com.iota.iri.controllers.TipsViewModel;
+import com.iota.iri.network.TransactionRequester;
+import com.iota.iri.storage.Tangle;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.core.util.Duration;
+
+/**
+ * This class deletes the database every Sunday at midnight, UTC. Its purpose is
+ * to cap hard disk usage until local snapshots are merged into CLIRI.
+ */
+public class DatabaseRecycler {
+
+    private final Logger log = LoggerFactory.getLogger(TipsSolidifier.class);
+
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final TransactionValidator transactionValidator;
+    private final TransactionRequester transactionRequester;
+    private final TipsViewModel tipsViewModel;
+    private final Tangle tangle;
+
+    public DatabaseRecycler(TransactionValidator transactionValidator, TransactionRequester transactionRequester,
+        TipsViewModel tipsViewModel, Tangle tangle) {
+        this.transactionRequester = transactionRequester;
+        this.transactionValidator = transactionValidator;
+        this.tipsViewModel = tipsViewModel;
+        this.tangle = tangle;
+    }
+
+    public void init(Date now) throws Exception {
+        final long oneWeekInMs = Duration.buildByDays(7).getMilliseconds();
+        final LocalDate nextSundayDate = now.toInstant().atZone(ZoneId.of("UTC")).toLocalDate().with(next(SUNDAY));
+        final long nextSunday = Date.from(nextSundayDate.atStartOfDay(ZoneId.of("UTC")).toInstant()).getTime();
+
+        log.info(String.format("Time until next Sunday: %d", nextSunday - now.getTime()));
+        log.info(String.format("Time between consecutive runs: %d", oneWeekInMs));
+
+        scheduler.scheduleAtFixedRate(recycle, nextSunday - now.getTime(), oneWeekInMs, TimeUnit.MILLISECONDS);
+    }
+
+    protected final Runnable recycle = new Runnable() {
+        public void run() {
+            log.info(String.format("Recycling database at %s", new Date().toString()));
+            TransactionValidator.setLatestEpochTimestamp(System.currentTimeMillis());
+            transactionRequester.clearQueue();
+            tipsViewModel.clear();
+
+            try {
+                tangle.clear();
+                transactionValidator.clear();
+            } catch (Exception e) {
+                log.error(e.toString(), e);
+            }
+        }
+    };
+}

--- a/src/main/java/com/iota/iri/storage/PersistenceProvider.java
+++ b/src/main/java/com/iota/iri/storage/PersistenceProvider.java
@@ -51,4 +51,5 @@ public interface PersistenceProvider {
 
     void clear(Class<?> column) throws Exception;
     void clearMetadata(Class<?> column) throws Exception;
+    void clearAll() throws Exception;
 }

--- a/src/main/java/com/iota/iri/storage/Tangle.java
+++ b/src/main/java/com/iota/iri/storage/Tangle.java
@@ -203,7 +203,7 @@ public class Tangle {
         }
     }
 
-    public void clear() throws Exception {
+    public void clearAll() throws Exception {
         for(PersistenceProvider provider: persistenceProviders) {
             provider.clearAll();
         }

--- a/src/main/java/com/iota/iri/storage/Tangle.java
+++ b/src/main/java/com/iota/iri/storage/Tangle.java
@@ -203,6 +203,12 @@ public class Tangle {
         }
     }
 
+    public void clear() throws Exception {
+        for(PersistenceProvider provider: persistenceProviders) {
+            provider.clearAll();
+        }
+    }
+
     /*
     public boolean merge(Persistable model, Indexable index) throws Exception {
         boolean exists = false;

--- a/src/main/java/com/iota/iri/storage/ZmqPublishProvider.java
+++ b/src/main/java/com/iota/iri/storage/ZmqPublishProvider.java
@@ -176,6 +176,11 @@ public class ZmqPublishProvider implements PersistenceProvider {
     }
 
     @Override
+    public void clearAll() throws Exception {
+
+    }
+
+    @Override
     public void clearMetadata(Class<?> column) throws Exception {
 
     }

--- a/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
+++ b/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
@@ -385,6 +385,14 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         return false;
     }
 
+    @Override
+    public void clearAll() throws Exception {
+        log.info("Deleting all entries");
+        for(ColumnFamilyHandle handle: classTreeMap.values()) {
+            flushHandle(handle);
+        }
+    }
+
     // 2018 March 28 - Unused Code
     public void createBackup(String path) throws RocksDBException {
         try (Env env = Env.getDefault();

--- a/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
+++ b/src/main/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProvider.java
@@ -391,6 +391,11 @@ public class RocksDBPersistenceProvider implements PersistenceProvider {
         for(ColumnFamilyHandle handle: classTreeMap.values()) {
             flushHandle(handle);
         }
+
+        log.info("Deleting all metadata entries");
+        for (ColumnFamilyHandle handle : metadataReference.values()) {
+            flushHandle(handle);
+        }
     }
 
     // 2018 March 28 - Unused Code

--- a/src/test/java/com/iota/iri/TransactionValidatorTest.java
+++ b/src/test/java/com/iota/iri/TransactionValidatorTest.java
@@ -244,7 +244,7 @@ public class TransactionValidatorTest {
 
     assertFalse(txValidator.isNewSolidTxSetsEmpty());
 
-    txValidator.clear();
+    txValidator.clearSolidTransactionsQueue();
 
     assertTrue(txValidator.isNewSolidTxSetsEmpty());
   }

--- a/src/test/java/com/iota/iri/TransactionValidatorTest.java
+++ b/src/test/java/com/iota/iri/TransactionValidatorTest.java
@@ -3,6 +3,7 @@ package com.iota.iri;
 import com.iota.iri.controllers.TipsViewModel;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.crypto.SpongeFactory;
+import com.iota.iri.model.Hash;
 import com.iota.iri.model.TransactionHash;
 import com.iota.iri.network.TransactionRequester;
 import com.iota.iri.storage.Tangle;
@@ -235,6 +236,17 @@ public class TransactionValidatorTest {
     txValidator.runValidation(tx, ZERO_MWM);
     TransactionValidator.setLatestEpochTimestamp(0);
 
+  }
+
+  @Test
+  public void testClear() throws Exception {
+    txValidator.addSolidTransaction(Hash.NULL_HASH);
+
+    assertFalse(txValidator.isNewSolidTxSetsEmpty());
+
+    txValidator.clear();
+
+    assertTrue(txValidator.isNewSolidTxSetsEmpty());
   }
 
   private TransactionViewModel getTxWithoutBranchAndTrunk() throws Exception {

--- a/src/test/java/com/iota/iri/controllers/TipsViewModelTest.java
+++ b/src/test/java/com/iota/iri/controllers/TipsViewModelTest.java
@@ -117,4 +117,23 @@ public class TipsViewModelTest {
         assertEquals(capacity * 2, tipsVM.size());
     }
 
+    @Test
+    public void tipsEmtpyAfterClear() throws Exception {
+        TipsViewModel tipsVM = new TipsViewModel();
+
+        int size = 60;
+
+        //fill tips list
+        for (int i = 0; i < size; i++) {
+            Hash hash = TransactionViewModelTest.getRandomTransactionHash();
+            tipsVM.addTipHash(hash);
+        }
+
+        assertEquals(size, tipsVM.size());
+
+        tipsVM.clear();
+
+        assertEquals(0, tipsVM.size());
+    } 
+
 }

--- a/src/test/java/com/iota/iri/controllers/TransactionRequesterTest.java
+++ b/src/test/java/com/iota/iri/controllers/TransactionRequesterTest.java
@@ -87,15 +87,16 @@ public class TransactionRequesterTest {
 
     @Test
     public void queueIsEmptyAfterCallingClearQueue() throws Exception {
+        final int txCount = 60;
         TransactionRequester txReq = new TransactionRequester(tangle, mq);
 
         //fill tips list
-        for (int i = 0; i < 60; i++) {
+        for (int i = 0; i < txCount; i++) {
             Hash hash = TransactionViewModelTest.getRandomTransactionHash();
             txReq.requestTransaction(hash);
         }
 
-        assertEquals(60, txReq.numberOfTransactionsToRequest());
+        assertEquals(txCount, txReq.numberOfTransactionsToRequest());
 
         txReq.clearQueue();
 

--- a/src/test/java/com/iota/iri/controllers/TransactionRequesterTest.java
+++ b/src/test/java/com/iota/iri/controllers/TransactionRequesterTest.java
@@ -84,4 +84,21 @@ public class TransactionRequesterTest {
         //check that limit wasn't breached
         assertEquals(capacity, txReq.numberOfTransactionsToRequest());
     }
+
+    @Test
+    public void queueIsEmptyAfterCallingClearQueue() throws Exception {
+        TransactionRequester txReq = new TransactionRequester(tangle, mq);
+
+        //fill tips list
+        for (int i = 0; i < 60; i++) {
+            Hash hash = TransactionViewModelTest.getRandomTransactionHash();
+            txReq.requestTransaction(hash);
+        }
+
+        assertEquals(60, txReq.numberOfTransactionsToRequest());
+
+        txReq.clearQueue();
+
+        assertEquals(0, txReq.numberOfTransactionsToRequest());
+    }
 }

--- a/src/test/java/com/iota/iri/service/APIIntegrationTests.java
+++ b/src/test/java/com/iota/iri/service/APIIntegrationTests.java
@@ -8,6 +8,7 @@ import com.iota.iri.conf.IotaConfig;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.crypto.SpongeFactory;
 import com.iota.iri.model.TransactionHash;
+import com.iota.iri.TransactionValidator;
 import com.iota.iri.utils.Converter;
 
 import java.util.HashMap;
@@ -91,6 +92,9 @@ public class APIIntegrationTests {
                 iota.init();
                 api.init();
                 ixi.init(IXIConfig.IXI_DIR);
+
+                // set epoch timestamp to not clash with hard-coded transaction test-cases.
+                TransactionValidator.setLatestEpochTimestamp(0);
             } catch (final Exception e) {
                 log.error("Exception during IOTA node initialisation: ", e);
                 fail("Exception during IOTA node initialisation");

--- a/src/test/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProviderTest.java
+++ b/src/test/java/com/iota/iri/storage/rocksDB/RocksDBPersistenceProviderTest.java
@@ -79,6 +79,25 @@ public class RocksDBPersistenceProviderTest {
         }
     }
 
+    @Test
+    public void testClearAll() throws Exception {
+        Persistable tx = new Transaction();
+        byte[] bytes = new byte[Transaction.SIZE];
+        Arrays.fill(bytes, (byte) 1);
+        tx.read(bytes);
+        tx.readMetadata(bytes);
+        List<Pair<Indexable, Persistable>> models = IntStream.range(1, 1000)
+                .mapToObj(i -> new Pair<>((Indexable) new IntegerIndex(i), tx))
+                .collect(Collectors.toList());
+
+        rocksDBPersistenceProvider.saveBatch(models);
+
+        Assert.assertArrayEquals(tx.bytes(), rocksDBPersistenceProvider.get(Transaction.class, new IntegerIndex(1)).bytes());
+
+        rocksDBPersistenceProvider.clearAll();
+
+        Assert.assertNull(rocksDBPersistenceProvider.get(Transaction.class, new IntegerIndex(1)).bytes());
+    }
 
 
 }


### PR DESCRIPTION
Fixes #76 

Every Sunday, UTC 00:00:00, delete the database and start from scratch. In addition, CLIRI will no longer accept old transactions (more than 10 minutes behind the timestamp).