### PR TITLE
Revert "EntryPointSelector to choose a transaction below the threshol…

### DIFF
--- a/src/main/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorCumulativeWeightThreshold.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorCumulativeWeightThreshold.java
@@ -105,20 +105,17 @@ public class EntryPointSelectorCumulativeWeightThreshold implements EntryPointSe
      */
     private Hash backtrack(Hash tip, int threshold) throws Exception {
         Hash currentHash = tip;
-        Hash previousHash = tip;
         int currentWeight = 1;
         int stepSize = 1;
 
         // Backtrack as long as the genesis hasn't been reached and the threshold has not been crossed
         while (currentWeight < threshold && !isGenesis(currentHash)) {
-            previousHash = currentHash;
             currentHash = nStepsBack(currentHash, stepSize);
             currentWeight = cumulativeWeightCalculator.calculateSingle(currentHash);
             stepSize *= 2;
         }
 
-        // Return the last transaction that did not cross the treshold
-        return previousHash;
+        return currentHash;
     }
 
     private Hash nStepsBack(Hash from, int steps) throws Exception {


### PR DESCRIPTION
This reverts commit 021b89442cda81bc086c9c2545321dea343c0162, which caused the Tangle to split into snakelike subtangles (rather than fail with a subtangle-too-big error).
