### PR TITLE
Entry point largest comp

### DIFF
--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -186,8 +186,9 @@ public class Iota {
         RatingCalculator ratingCalculator = new CumulativeWeightCalculator(tangle);
         TailFinder tailFinder = new TailFinderImpl(tangle);
         Walker walker = new WalkerAlpha(tailFinder, tangle, messageQ, new SecureRandom(), config);
-        EntryPointSelector entryPointSelector = new EntryPointSelectorCumulativeWeightThreshold(tangle, tipsViewModel,
-            CumulativeWeightCalculator.MAX_FUTURE_SET_SIZE);
+        StartingTipSelector startingTipSelector = new ConnectedComponentsStartingTipSelector(tangle, CumulativeWeightCalculator.MAX_FUTURE_SET_SIZE, tipsViewModel);
+        EntryPointSelector entryPointSelector = new EntryPointSelectorCumulativeWeightThreshold(
+            tangle, CumulativeWeightCalculator.MAX_FUTURE_SET_SIZE, startingTipSelector);
         ReferenceChecker referenceChecker = new ReferenceCheckerImpl(tangle);
         return new TipSelectorImpl(tangle, ledgerValidator, entryPointSelector, ratingCalculator, walker, referenceChecker);
     }

--- a/src/main/java/com/iota/iri/service/tipselection/StartingTipSelector.java
+++ b/src/main/java/com/iota/iri/service/tipselection/StartingTipSelector.java
@@ -1,0 +1,12 @@
+package com.iota.iri.service.tipselection;
+
+import com.iota.iri.model.Hash;
+
+/**
+ * Functional interface for selecting a tip to start backtracking from,
+ * used in EntryPointSelectorCumulativeWeightThreshold.
+ */
+
+public interface StartingTipSelector {
+    Hash getTip() throws Exception;
+}

--- a/src/main/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsCalculator.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsCalculator.java
@@ -21,7 +21,7 @@ public class ConnectedComponentsCalculator {
         this.random = new SecureRandom();
     }
 
-    public Collection<Set<Hash>> getConnectedComponents(Set<Hash> transactions) throws Exception {
+    public Collection<Set<Hash>> getConnectedComponents(Collection<Hash> transactions) throws Exception {
         Set<Hash> unvisited = new HashSet<>(transactions);
         List<Set<Hash>> result = new ArrayList<>();
 
@@ -39,8 +39,8 @@ public class ConnectedComponentsCalculator {
                     unvisited.remove(currentHash);
                     currentComponent.add(currentHash);
 
-                    getNeighbors(currentHash).stream()
-                        .filter(t -> unvisited.contains(t))
+                    getAdjacent(currentHash).stream()
+                        .filter(unvisited::contains)
                         .forEach(stack::push);
                 }
             }
@@ -51,7 +51,7 @@ public class ConnectedComponentsCalculator {
         return result;
     }
 
-    private Collection<Hash> getNeighbors(Hash hash) throws Exception {
+    private Collection<Hash> getAdjacent(Hash hash) throws Exception {
         Collection<Hash> result = new HashSet<>();
 
         TransactionViewModel transaction = TransactionViewModel.fromHash(tangle, hash);

--- a/src/main/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsStartingTipSelector.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsStartingTipSelector.java
@@ -35,7 +35,7 @@ public class ConnectedComponentsStartingTipSelector implements StartingTipSelect
         return this.randomlySelectTipFromLargestConnectedComponent(components, latestTips);
     }
 
-    public Collection<Set<Hash>> getConnectedComponents(Collection<Hash> transactions) throws Exception {
+    private Collection<Set<Hash>> getConnectedComponents(Collection<Hash> transactions) throws Exception {
         Set<Hash> unvisited = new HashSet<>(transactions);
         List<Set<Hash>> result = new ArrayList<>();
 
@@ -76,7 +76,7 @@ public class ConnectedComponentsStartingTipSelector implements StartingTipSelect
         return result;
     }
 
-    public Collection<Hash> findNMostRecentTransactions(Collection<Hash> tips) throws Exception {
+    private Collection<Hash> findNMostRecentTransactions(Collection<Hash> tips) throws Exception {
 
         Collection<Hash> result = new HashSet<>(maxTransactions);
 
@@ -106,7 +106,7 @@ public class ConnectedComponentsStartingTipSelector implements StartingTipSelect
         return result;
     }
 
-    public Hash randomlySelectTipFromLargestConnectedComponent(Collection<Set<Hash>> connectedComponents,
+    private Hash randomlySelectTipFromLargestConnectedComponent(Collection<Set<Hash>> connectedComponents,
                                                                Collection<Hash> tips) {
         Collection<Hash> largestComponent = connectedComponents.stream()
                 .max(Comparator.comparing(Collection::size))

--- a/src/main/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsStartingTipSelector.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsStartingTipSelector.java
@@ -22,7 +22,7 @@ public class ConnectedComponentsStartingTipSelector implements StartingTipSelect
     public ConnectedComponentsStartingTipSelector(Tangle tangle, int maxTransactions, TipsViewModel tipsViewModel) {
         this.tangle = tangle;
         this.maxTransactions = maxTransactions;
-        this.maxInitialTips = maxTransactions / 4;
+        this.maxInitialTips = (int) Math.sqrt(maxTransactions);
         this.tipsViewModel = tipsViewModel;
         this.random = new SecureRandom();
     }

--- a/src/main/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorCumulativeWeightThreshold.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorCumulativeWeightThreshold.java
@@ -1,15 +1,11 @@
 package com.iota.iri.service.tipselection.impl;
 
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.Objects;
-import java.util.Queue;
 
-import com.iota.iri.controllers.ApproveeViewModel;
-import com.iota.iri.controllers.TipsViewModel;
 import com.iota.iri.controllers.TransactionViewModel;
 import com.iota.iri.model.Hash;
 import com.iota.iri.service.tipselection.EntryPointSelector;
+import com.iota.iri.service.tipselection.StartingTipSelector;
 import com.iota.iri.storage.Tangle;
 
 import org.apache.commons.lang3.NotImplementedException;
@@ -21,16 +17,16 @@ import org.apache.commons.lang3.NotImplementedException;
 public class EntryPointSelectorCumulativeWeightThreshold implements EntryPointSelector {
     public final Tangle tangle;
     private final CumulativeWeightCalculator cumulativeWeightCalculator;
-    private final TipsViewModel tipsViewModel;
+    private final StartingTipSelector startingTipSelector;
     private final int threshold;
 
     public static int MAX_SUBTANGLE_SIZE = 4 * CumulativeWeightCalculator.MAX_FUTURE_SET_SIZE;
 
-    public EntryPointSelectorCumulativeWeightThreshold(Tangle tangle, TipsViewModel tipsViewModel, int threshold) {
+    public EntryPointSelectorCumulativeWeightThreshold(Tangle tangle, int threshold, StartingTipSelector startingTipSelector) {
         this.tangle = tangle;
         this.cumulativeWeightCalculator = new CumulativeWeightCalculator(tangle);
-        this.tipsViewModel = tipsViewModel;
         this.threshold = threshold;
+        this.startingTipSelector = startingTipSelector;
     }
 
     @Override
@@ -40,8 +36,7 @@ public class EntryPointSelectorCumulativeWeightThreshold implements EntryPointSe
 
     @Override
     public Hash getEntryPoint() throws Exception {
-        Hash tip = tipsViewModel.getRandomSolidTipHash();
-        Hash entryPoint = backtrack(tip, threshold);
+        Hash entryPoint = backtrack(this.startingTipSelector.getTip(), threshold);
 
         int subtangleWeight = cumulativeWeightCalculator.calculateSingle(entryPoint);
         if (subtangleWeight > MAX_SUBTANGLE_SIZE) {

--- a/src/test/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsCalculatorTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsCalculatorTest.java
@@ -197,7 +197,7 @@ public class ConnectedComponentsCalculatorTest {
     @Test
     public void getConnectedComponentsReturnsCorrectSetsForStar() throws Exception {
         final int amount = 10;
-        Set<Hash> loneTransactions = new HashSet<Hash>(makeStar(amount, Hash.NULL_HASH, 0));
+        Set<Hash> loneTransactions = new HashSet<>(makeStar(amount, Hash.NULL_HASH, 0));
 
         ConnectedComponentsCalculator connectedComponentsCalculator = new ConnectedComponentsCalculator(tangle, maxTransaction);
         Collection<Set<Hash>> components = connectedComponentsCalculator.getConnectedComponents(loneTransactions);


### PR DESCRIPTION
Fixes #86, consolidates #88 #89 #90 into a single class and chooses the starting tip from the largest connected component among recent transactions.