### PR TITLE
findNMostRecentTransactions: only add to queue txs that have never been visited

### DIFF
--- a/src/main/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsStartingTipSelector.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsStartingTipSelector.java
@@ -76,7 +76,7 @@ public class ConnectedComponentsStartingTipSelector implements StartingTipSelect
         return result;
     }
 
-    private Collection<Hash> findNMostRecentTransactions(Collection<Hash> tips) throws Exception {
+    private Collection<Hash> findNMostRecentTransactions(Collection<Hash> tips) {
 
         Collection<Hash> result = new HashSet<>(maxTransactions);
 
@@ -87,6 +87,7 @@ public class ConnectedComponentsStartingTipSelector implements StartingTipSelect
 
         //the heap is initialized with the tips.
         tips.stream().map(this::fromHash).forEach(queue::add);
+        visited.addAll(tips);
 
         while (!queue.isEmpty() && result.size() < maxTransactions) {
             TransactionViewModel current = queue.poll();
@@ -96,13 +97,12 @@ public class ConnectedComponentsStartingTipSelector implements StartingTipSelect
             Hash trunkHash = current.getTrunkTransactionHash();
             Hash branchHash = current.getBranchTransactionHash();
 
-            if (!visited.contains(trunkHash)) {
-                queue.add(current.getTrunkTransaction(tangle));
-                visited.add(trunkHash);
-            }
-            if (!visited.contains(branchHash)) {
-                queue.add(current.getBranchTransaction(tangle));
-                visited.add(branchHash);
+            List<Hash> approvees = Arrays.asList(trunkHash, branchHash);
+            for (Hash approvee: approvees) {
+                if (!visited.contains(approvee)) {
+                    queue.add(fromHash(approvee));
+                    visited.add(approvee);
+                }
             }
         }
 

--- a/src/main/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsStartingTipSelector.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsStartingTipSelector.java
@@ -76,7 +76,7 @@ public class ConnectedComponentsStartingTipSelector implements StartingTipSelect
         return result;
     }
 
-    private Collection<Hash> findNMostRecentTransactions(Collection<Hash> tips) {
+    private Collection<Hash> findNMostRecentTransactions(Collection<Hash> tips) throws Exception {
 
         Collection<Hash> result = new HashSet<>(maxTransactions);
 
@@ -100,7 +100,7 @@ public class ConnectedComponentsStartingTipSelector implements StartingTipSelect
             List<Hash> approvees = Arrays.asList(trunkHash, branchHash);
             for (Hash approvee: approvees) {
                 if (!visited.contains(approvee)) {
-                    queue.add(fromHash(approvee));
+                    queue.add(TransactionViewModel.fromHash(tangle, approvee));
                     visited.add(approvee);
                 }
             }

--- a/src/main/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsStartingTipSelector.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/ConnectedComponentsStartingTipSelector.java
@@ -83,6 +83,7 @@ public class ConnectedComponentsStartingTipSelector implements StartingTipSelect
         //using a max heap sorted by arrivalTime.
         Queue<TransactionViewModel> queue = new PriorityQueue<>(maxTransactions,
                 Comparator.comparingLong(a -> (-1) * a.getArrivalTime()));
+        Set<Hash> visited = new HashSet<>(maxTransactions);
 
         //the heap is initialized with the tips.
         tips.stream().map(this::fromHash).forEach(queue::add);
@@ -95,11 +96,13 @@ public class ConnectedComponentsStartingTipSelector implements StartingTipSelect
             Hash trunkHash = current.getTrunkTransactionHash();
             Hash branchHash = current.getBranchTransactionHash();
 
-            if (!result.contains(trunkHash)) {
+            if (!visited.contains(trunkHash)) {
                 queue.add(current.getTrunkTransaction(tangle));
+                visited.add(trunkHash);
             }
-            if (!trunkHash.equals(branchHash) && !result.contains(branchHash)) {
+            if (!visited.contains(branchHash)) {
                 queue.add(current.getBranchTransaction(tangle));
+                visited.add(branchHash);
             }
         }
 


### PR DESCRIPTION
this fixes a regression in tip connected components selection.
the queue would fill with duplicate transactions and grow rapidly.

tested on a local Tangle.

to reproduce the bug:
1. start a node with an empty DB.
2. spam for ~70 transactions.
3. you will see that the timing of GTTA degrades rapidly after that.