### PR TITLE
EntryPointSelector returns tail tx

### DIFF
--- a/src/main/java/com/iota/iri/Iota.java
+++ b/src/main/java/com/iota/iri/Iota.java
@@ -188,7 +188,7 @@ public class Iota {
         Walker walker = new WalkerAlpha(tailFinder, tangle, messageQ, new SecureRandom(), config);
         StartingTipSelector startingTipSelector = new ConnectedComponentsStartingTipSelector(tangle, CumulativeWeightCalculator.MAX_FUTURE_SET_SIZE, tipsViewModel);
         EntryPointSelector entryPointSelector = new EntryPointSelectorCumulativeWeightThreshold(
-            tangle, CumulativeWeightCalculator.MAX_FUTURE_SET_SIZE, startingTipSelector);
+            tangle, CumulativeWeightCalculator.MAX_FUTURE_SET_SIZE, startingTipSelector, tailFinder);
         ReferenceChecker referenceChecker = new ReferenceCheckerImpl(tangle);
         return new TipSelectorImpl(tangle, ledgerValidator, entryPointSelector, ratingCalculator, walker, referenceChecker);
     }

--- a/src/test/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorCumulativeWeightThresholdTest.java
+++ b/src/test/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorCumulativeWeightThresholdTest.java
@@ -210,7 +210,8 @@ public class EntryPointSelectorCumulativeWeightThresholdTest {
         Mockito.when(tailFinder.findTail(Mockito.any(Hash.class)))
             .thenReturn(Optional.of(tail));
 
-        EntryPointSelector entryPointSelector = new EntryPointSelectorCumulativeWeightThreshold(tangle, threshold, startingTipSelector, tailFinder); Hash entryPoint = entryPointSelector.getEntryPoint(); 
+        EntryPointSelector entryPointSelector = new EntryPointSelectorCumulativeWeightThreshold(tangle, threshold, startingTipSelector, tailFinder);
+        Hash entryPoint = entryPointSelector.getEntryPoint(); 
 
         Assert.assertEquals(tail, entryPoint);
     }
@@ -228,7 +229,8 @@ public class EntryPointSelectorCumulativeWeightThresholdTest {
             .thenReturn(Optional.empty());
 
         exception.expect(NoSuchElementException.class);
-        EntryPointSelector entryPointSelector = new EntryPointSelectorCumulativeWeightThreshold(tangle, threshold, startingTipSelector, tailFinder); Hash entryPoint = entryPointSelector.getEntryPoint(); 
+        EntryPointSelector entryPointSelector = new EntryPointSelectorCumulativeWeightThreshold(tangle, threshold, startingTipSelector, tailFinder);
+        entryPointSelector.getEntryPoint(); 
     }
 
     private List<Hash> makeChain(int length) throws Exception {


### PR DESCRIPTION
Fixes #99 , which is necessary for value transactions to work (and to test CLIRI on main net databases).