### PR TITLE
move tips population to `getLatestSolidTips`

### DIFF
--- a/src/main/java/com/iota/iri/controllers/TipsViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TipsViewModel.java
@@ -78,7 +78,11 @@ public class TipsViewModel {
         return result;
     }
 
-    public Hash getRandomSolidTipHash() throws Exception {
+    public Hash getRandomSolidTipHash() {
+        if (solidSize() == 0) {
+            return Hash.NULL_HASH;
+        }
+
         synchronized (sync) {
             int index = seed.nextInt(solidTips.size());
             Iterator<Hash> hashIterator;

--- a/src/main/java/com/iota/iri/controllers/TipsViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TipsViewModel.java
@@ -4,7 +4,14 @@ import com.iota.iri.model.Hash;
 import com.iota.iri.storage.Tangle;
 
 import java.security.SecureRandom;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
 
 public class TipsViewModel {
 

--- a/src/main/java/com/iota/iri/controllers/TipsViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TipsViewModel.java
@@ -1,17 +1,10 @@
 package com.iota.iri.controllers;
 
-import java.security.SecureRandom;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Queue;
-import java.util.Set;
-
 import com.iota.iri.model.Hash;
 import com.iota.iri.storage.Tangle;
+
+import java.security.SecureRandom;
+import java.util.*;
 
 public class TipsViewModel {
 
@@ -67,7 +60,12 @@ public class TipsViewModel {
         return hashes;
     }
 
-    public List<Hash> getLatestSolidTips(int count) {
+    public List<Hash> getLatestSolidTips(int count) throws Exception {
+        synchronized (sync) {
+            if (solidTips.size() == 0) {
+                populateSolidTips();
+            }
+        }
         List<Hash> result = new ArrayList<>();
         
         int i = 0;
@@ -82,9 +80,6 @@ public class TipsViewModel {
 
     public Hash getRandomSolidTipHash() throws Exception {
         synchronized (sync) {
-            if (solidTips.size() == 0) {
-                populateSolidTips();
-            }
             int index = seed.nextInt(solidTips.size());
             Iterator<Hash> hashIterator;
             hashIterator = solidTips.iterator();

--- a/src/test/java/com/iota/iri/controllers/TipsViewModelTest.java
+++ b/src/test/java/com/iota/iri/controllers/TipsViewModelTest.java
@@ -1,10 +1,12 @@
 package com.iota.iri.controllers;
 
-import static com.iota.iri.controllers.TransactionViewModelTest.getRandomTransactionHash;
-import static com.iota.iri.controllers.TransactionViewModelTest.getRandomTransactionWithTrunkAndBranch;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import com.iota.iri.model.Hash;
+import com.iota.iri.storage.Tangle;
+import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -12,14 +14,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
-import com.iota.iri.model.Hash;
-import com.iota.iri.storage.Tangle;
-import com.iota.iri.storage.rocksDB.RocksDBPersistenceProvider;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static com.iota.iri.controllers.TransactionViewModelTest.getRandomTransactionHash;
+import static com.iota.iri.controllers.TransactionViewModelTest.getRandomTransactionWithTrunkAndBranch;
+import static org.junit.Assert.*;
 
 /**
  * Created by paul on 5/2/17.
@@ -174,10 +171,10 @@ public class TipsViewModelTest {
 
         TipsViewModel tipsVM = new TipsViewModel(tangle);
 
-        Hash tip = tipsVM.getRandomSolidTipHash();
+        List<Hash> solidTips = tipsVM.getLatestSolidTips(1);
 
-        assertNotNull(tip);
-        assertTrue(tips.contains(tip));
+        assertNotNull(solidTips);
+        assertTrue(tips.contains(solidTips.get(0)));
     }
 
     @Test
@@ -194,9 +191,9 @@ public class TipsViewModelTest {
 
         TipsViewModel tipsVM = new TipsViewModel(tangle);
 
-        Hash tip = tipsVM.getRandomSolidTipHash();
+        List<Hash> solidTips = tipsVM.getLatestSolidTips(1);
 
-        assertEquals(solidTip.getHash(), tip);
+        assertEquals(solidTip.getHash(), solidTips.get(0));
     }
 
     @Test


### PR DESCRIPTION
# Description

Tip population should be triggered by tip selection, and not a random tip request (which happens periodically) - b/c population might be a heavy process.

Fixes #97 

# How Has This Been Tested?
- Local node w/ empty DB, stopped producing that Exception.