### PR TITLE
Raised entry point weight threshold

### DIFF
--- a/src/main/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorCumulativeWeightThreshold.java
+++ b/src/main/java/com/iota/iri/service/tipselection/impl/EntryPointSelectorCumulativeWeightThreshold.java
@@ -22,7 +22,7 @@ public class EntryPointSelectorCumulativeWeightThreshold implements EntryPointSe
     private final int threshold;
     private final TailFinder tailFinder;
 
-    public static int MAX_SUBTANGLE_SIZE = 4 * CumulativeWeightCalculator.MAX_FUTURE_SET_SIZE;
+    public static int MAX_SUBTANGLE_SIZE = 15 * CumulativeWeightCalculator.MAX_FUTURE_SET_SIZE;
 
     public EntryPointSelectorCumulativeWeightThreshold(Tangle tangle, int threshold,
             StartingTipSelector startingTipSelector, TailFinder tailFinder) {


### PR DESCRIPTION
Znet tip selection was failing with the following error: `The selected entry point's subtangle size is too big. EntryPoint Hash: EXFBOUKIDMWAHEKNIHVAH9YZLEYYOMPKTBTEOEZQGVZVOWWUQYUBDHPQCMBUFFLLTCVWWMRKBTJC99999 Subtangle size: 1939`

The quick and dirty mitigation is to raise the threshold, and we'll also open an issue.
