### PR TITLE
Make getLatestSolidTips synchronized

### DIFF
--- a/src/main/java/com/iota/iri/controllers/TipsViewModel.java
+++ b/src/main/java/com/iota/iri/controllers/TipsViewModel.java
@@ -68,20 +68,19 @@ public class TipsViewModel {
     }
 
     public List<Hash> getLatestSolidTips(int count) throws Exception {
+        List<Hash> result = new ArrayList<>();
         synchronized (sync) {
             if (solidTips.size() == 0) {
                 populateSolidTips();
             }
-        }
-        List<Hash> result = new ArrayList<>();
-        
-        int i = 0;
-        Iterator<Hash> hashIterator = solidTips.descendingIterator();
-        while (hashIterator.hasNext() && i < count) {
-            result.add(hashIterator.next());
-            i++;
-        }
 
+            int i = 0;
+            Iterator<Hash> hashIterator = solidTips.descendingIterator();
+            while (hashIterator.hasNext() && i < count) {
+                result.add(hashIterator.next());
+                i++;
+            }
+        }
         return result;
     }
 


### PR DESCRIPTION
Any access of `TipsViewModel#solidTips` should be synchronized to avoid race conditions; could be related to #111.