### PR TITLE
Update dockerfile to match CLIRI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,22 @@
-ENV DOCKER_IRI_JAR_PATH "/iri/target/cliri*.jar"
+ARG IRITYPE=cliri
 
 FROM iotacafe/maven:3.5.4.oracle8u181.1.webupd8.1.1-1 as local_stage_build
 MAINTAINER giorgio@iota.org
-
-WORKDIR /iri
-
-COPY . /iri
+ARG IRITYPE
+RUN git clone https://github.com/iotaledger/${IRITYPE}.git
+WORKDIR /${IRITYPE}
 RUN mvn clean package
 
 # execution image
-FROM iotacafe/java:oracle8u181.1.webupd8.1-1
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        jq curl socat \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY --from=local_stage_build $DOCKER_IRI_JAR_PATH /iri/target/
-COPY docker/entrypoint.sh /
-
-# Java related options. Defaults set as below
-ENV JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+DisableAttachMechanism -XX:InitiatingHeapOccupancyPercent=60 -XX:G1MaxNewSizePercent=75 -XX:MaxGCPauseMillis=10000 -XX:+UseG1GC"
-ENV JAVA_MIN_MEMORY 2G
-ENV JAVA_MAX_MEMORY 4G
-
-# Additional custom variables. See DOCKER.md for details
-ENV DOCKER_IRI_REMOTE_LIMIT_API "interruptAttachToTangle, attachToTangle, addNeighbors, removeNeighbors, getNeighbors"
-
+#FROM iotacafe/java:oracle8u181.1.webupd8.1-1
+FROM openjdk:jre-slim
+ARG IRITYPE
+ENV DOCKER_IRI_JAR_PATH=/${IRITYPE}/target/${IRITYPE}*.jar \
+    DOCKER_IRI_REMOTE_LIMIT_API="interruptAttachToTangle, attachToTangle, addNeighbors, removeNeighbors, getNeighbors" \
+    DOCKER_IRI_MONITORING_API_PORT_DESTINATION=14265 \
+    JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+DisableAttachMechanism -XX:InitiatingHeapOccupancyPercent=60 -XX:G1MaxNewSizePercent=75 -XX:MaxGCPauseMillis=10000 -XX:+UseG1GC" \
+    JAVA_MIN_MEMORY=2G \
+    JAVA_MAX_MEMORY=4G
 # Setting this to 1 will have socat exposing 14266 and pointing it on
 # localhost. See /entrypoint.sh
 # !!! DO NOT DOCKER EXPOSE (-p) 14266 as the remote api settings
@@ -33,7 +24,9 @@ ENV DOCKER_IRI_REMOTE_LIMIT_API "interruptAttachToTangle, attachToTangle, addNei
 # You also have to maintain $DOCKER_IRI_MONITORING_API_PORT_DESTINATION
 # based on the actual API port exposed via IRI
 ENV DOCKER_IRI_MONITORING_API_PORT_ENABLE 0
-ENV DOCKER_IRI_MONITORING_API_PORT_DESTINATION 14265
 
-WORKDIR /iri/data
+RUN apt-get update && apt-get install -y jq curl socat --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=local_stage_build $DOCKER_IRI_JAR_PATH /iri.jar
+COPY ./docker/entrypoint.sh /
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ ARG IRITYPE=cliri
 FROM iotacafe/maven:3.5.4.oracle8u181.1.webupd8.1.1-1 as local_stage_build
 MAINTAINER giorgio@iota.org
 ARG IRITYPE
-RUN git clone https://github.com/iotaledger/${IRITYPE}.git
 WORKDIR /${IRITYPE}
+COPY . /${IRITYPE}
 RUN mvn clean package
 
 # execution image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ENV DOCKER_IRI_JAR_PATH "/iri/target/cliri*.jar"
+
 FROM iotacafe/maven:3.5.4.oracle8u181.1.webupd8.1.1-1 as local_stage_build
 MAINTAINER giorgio@iota.org
 
@@ -13,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         jq curl socat \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=local_stage_build /iri/target/iri*.jar /iri/target/
+COPY --from=local_stage_build $DOCKER_IRI_JAR_PATH /iri/target/
 COPY docker/entrypoint.sh /
 
 # Java related options. Defaults set as below
@@ -22,7 +24,6 @@ ENV JAVA_MIN_MEMORY 2G
 ENV JAVA_MAX_MEMORY 4G
 
 # Additional custom variables. See DOCKER.md for details
-ENV DOCKER_IRI_JAR_PATH "/iri/target/iri*.jar"
 ENV DOCKER_IRI_REMOTE_LIMIT_API "interruptAttachToTangle, attachToTangle, addNeighbors, removeNeighbors, getNeighbors"
 
 # Setting this to 1 will have socat exposing 14266 and pointing it on

--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ java -jar iri.jar -p 14265
 
 Building the image is straight forward. While inside the cliri-repository folder simply run
 
-`docker build -t iotaledger/iri:latest .`
+`docker build -t iotaledger/cliri:latest .`
 
 #### Starting a container
 
 Create an iota.ini file (for example in your home directory) with all of your configuration variables set in it.
 Any that you don't provide in here will be assumed to be default or taken from command line arguments. This iota.ini will be mounted as /iota.ini inside the container and will automatically be loaded by cliri once started.
 
-`docker run --name iota-node -v ~/iota.ini:/iota.ini iotaledger/iri:latest`
+`docker run --name iota-node -v ~/iota.ini:/iota.ini iotaledger/cliri:latest`
 
 ### Command Line Options 
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,18 @@ java -jar iri.jar -p 14265
 
 ### Docker
 
-Create an iota.ini file with all of your configuration variables set in it.
-Any that you don't provide in here will be assumed to be default or taken from
-command line arguments.
+#### Building the image
 
-`docker run -d --net=host --name iota-node -v iota.ini:/iri/iota.ini iotaledger/iri:latest`
+Building the image is straight forward. While inside the cliri-repository folder simply run
+
+`docker build -t iotaledger/iri:latest .`
+
+#### Starting a container
+
+Create an iota.ini file (for example in your home directory) with all of your configuration variables set in it.
+Any that you don't provide in here will be assumed to be default or taken from command line arguments. This iota.ini will be mounted as /iota.ini inside the container and will automatically be loaded by cliri once started.
+
+`docker run --name iota-node -v ~/iota.ini:/iota.ini iotaledger/iri:latest`
 
 ### Command Line Options 
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,6 +10,6 @@ exec java \
   -Xms$JAVA_MIN_MEMORY \
   -Xmx$JAVA_MAX_MEMORY \
   -Djava.net.preferIPv4Stack=true \
-  -jar $DOCKER_IRI_JAR_PATH \
+  -jar iri.jar \
   --remote --remote-limit-api "$DOCKER_IRI_REMOTE_LIMIT_API" \
   "$@"


### PR DESCRIPTION
# Description

The dockerfile right now can not be used since it will stop with errors. This new file can be used with IRI and CLIRI by simply setting the IRITYPE arg to IRI / CLIRI

Fixes #117  (issue)

## Type of change

- Breaking change

# How Has This Been Tested?

Setting the IRITYPE to CLIRI and building the image with `docker build` will create an image which can be used to run CLIRI.

# Checklist:

- [x] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
